### PR TITLE
Use setpriv instead of runuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can use the Quick Setup script or follow the manual steps.
     ```
 
 5.  **Configure PAM:**
-    Append the `pam_namespace.so` line to your PAM session configuration. I highly recommend trying `optional` first. If the mounts don't appear after relogin (check logs), change `optional` to `required`. Prioritized files for Debian-based systems are `/etc/pam.d/common-session` and `/etc/pam.d/common-session-noninteractive`.
+    Append the `pam_namespace.so` line to your PAM session configuration. I highly recommend trying `optional` first. If the mounts don't appear after relogin (check logs), change `optional` to `required`. Prioritized files for Debian-based systems are `/etc/pam.d/common-session` and `/etc/pam.d/common-session-noninteractive`. For Arch-based systems, the common login configuration file is `/etc/pam.d/system-login`.
 
     ```bash
     echo "session    optional    pam_namespace.so" | sudo tee -a "/etc/pam.d/common-session" "/etc/pam.d/common-session-noninteractive"

--- a/quick_setup.sh
+++ b/quick_setup.sh
@@ -14,8 +14,14 @@ INIT_SCRIPT_TARGET="$NAMESPACE_D_DIR/99-steamlibrary.init"
 TRIGGER_DIR="/opt/pam_namespace_steamlibrarytrigger"
 
 PAM_CONFIG_LINE="session    optional    pam_namespace.so"
-PAM_FILE1="/etc/pam.d/common-session"
-PAM_FILE2="/etc/pam.d/common-session-noninteractive"
+PAM_FILES=(
+    # Comment / uncomment paths as appropriate for your system.
+    # Debian
+    "/etc/pam.d/common-session"
+    "/etc/pam.d/common-session-noninteractive"
+    # Arch
+    #"/etc/pam.d/system-login"
+)
 
 # --- Execution ---
 
@@ -31,14 +37,16 @@ wget -q --show-progress -O "$INIT_SCRIPT_TARGET" "$INIT_SCRIPT_URL"
 chmod 755 "$INIT_SCRIPT_TARGET"
 
 echo "[4/4] Appending PAM configuration (using 'optional')..."
-echo "$PAM_CONFIG_LINE" | tee -a "$PAM_FILE1" >/dev/null
-echo "$PAM_CONFIG_LINE" | tee -a "$PAM_FILE2" >/dev/null
+for pam_file in "${PAM_FILES[@]}"; do
+    echo "$PAM_CONFIG_LINE" | tee -a "$pam_file" >/dev/null
+done
 
 # --- Completion ---
 echo
 echo ">>> Setup Complete <<<"
 echo "IMPORTANT:"
-echo "1. Review the appended lines in $PAM_FILE1 and/or $PAM_FILE2."
+echo "1. Review the appended lines in PAM file(s):"
+printf '   %s\n' "${PAM_FILES[@]}"
 echo "2. If login fails or mounts don't work after relogin, you might need"
 echo "   to change 'optional' to 'required' in the PAM file(s)."
 echo "3. A full **logout and login** (or reboot) is required for changes to take effect."

--- a/steamlibrary.init
+++ b/steamlibrary.init
@@ -28,11 +28,14 @@ if [ -z "$homedir" ] || ! [ -d "$homedir" ]; then
     exit 1
 fi
 
+readonly uid=$(id -u "$user")
+readonly gid=$(id -g "$user")
+
 log info "Processing trigger '$1' for user '$user' with home '$homedir'."
 
 # === Discover and Filter Steam Library Paths ===
 readonly VDF_FILE="${homedir}/.steam/steam/steamapps/libraryfolders.vdf"
-if ! runuser -u "$user" -- test -f "$VDF_FILE"; then
+if ! setpriv --reuid="$uid" --regid="$gid" --init-groups -- test -f "$VDF_FILE"; then
     log info "VDF file '$VDF_FILE' not found for user '$user'. No external libraries to process."
     exit 0
 fi
@@ -55,7 +58,7 @@ while IFS="" read -r lib_path || [ -n "$lib_path" ]; do
     full_target_path="${lib_path}/steamapps/compatdata"
     log debug "Found valid external target path: '$full_target_path'"
     VALID_TARGET_POLYDIRS+=("$full_target_path")
-done < <(runuser -u "$user" -- bash -c "grep '\"path\"' '$VDF_FILE' 2>/dev/null" | cut -d'"' -f4 | grep -v "^${homedir}")
+done < <(setpriv --reuid="$uid" --regid="$gid" --init-groups -- bash -c "grep '\"path\"' '$VDF_FILE' 2>/dev/null" | cut -d'"' -f4 | grep -v "^${homedir}")
 
 if [ ${#VALID_TARGET_POLYDIRS[@]} -eq 0 ]; then
     log info "No external (non-HOME) library paths found in VDF for user '$user'."


### PR DESCRIPTION
**Problem:** `runuser` uses PAM, so using it within a PAM trigger can cause infinite recursion. This problem was observed on an Arch-based system where `steamlibrary.init` is triggered by the `system-login` PAM file, leading to the following loop:
1. `steamlibrary.init` executes `runuser`
2. `runuser` PAM configuration includes `system-login`
3. `system-login` executes `steamlibrary.init` 

The fix is to replace uses of `runuser` with `setpriv` in the init script. This should operate the same except for skipping PAM.

Also updated documentation and `quick_setup.sh` to ease adaptation.

Note `runuser` and `setpriv` are both part of the `util-linux` package, so this shouldn't affect dependencies.